### PR TITLE
Update the list of AMI IDs to include RHEL 7.5

### DIFF
--- a/ansible_tower/group_vars/all_example
+++ b/ansible_tower/group_vars/all_example
@@ -29,12 +29,16 @@ tower_instance_type:              "t2.medium"    # Tower Instance Size
 node_instance_type:               "t2.small"     # Student Instance Size
 region:                           "us-east-1"    # AWS Region, configures ec2.ini too
 ebs_root_block_size:              50
-# ami_id:                         "" # Cloud Access RHEL 7.4 (NOVA us-east-1)
-# ami_id:                         "" # Cloud Access RHEL 7.4 (Ohio us-east-2)
-# ami_id:                         "ami-cfdafaaa" # us-east-2 RHEL 7.4 
-# ami_id:                         "ami-c11b32a4" # us-east-2 RHEL 7.4 with JBoss EAP 7.1
-# ami_id:                         "ami-c998b6b2" # us-east-1 RHEL 7.4
-# ami_id:                         "ami-a4791ede" # us-east-1 RHEL 7.4 with JBoss EAP 7.1
+# aws.infra                |      AWS AMI IDs
+#-------------------------------------------------------------------------------
+# us-east-1
+# ami_id:                         "ami-c998b6b2" # RHEL 7.4
+# ami_id:                         "ami-a4791ede" # RHEL 7.4 with JBoss EAP 7.1
+# ami_id:                         "ami-0d70a070" # RHEL 7.5
+# us-east-2
+# ami_id:                         "ami-cfdafaaa" # RHEL 7.4 
+# ami_id:                         "ami-c11b32a4" # RHEL 7.4 with JBoss EAP 7.1
+# ami_id:                         "ami-8f2617ea" # RHEL 7.5 
 #-------------------------------------------------------------------------------
 # subscription_manager     |      Red Hat Subscription via Cloud Access
 cloud_access:                      true


### PR DESCRIPTION
.  We are still waiting on RHEL 7.5 with JBoss AMIs to be available.