### PR TITLE
Fix broken deployment of OpenShift workshop due to AMI changes between versions

### DIFF
--- a/ansible_tower_aws/roles/aws.create/templates/hosts.j2
+++ b/ansible_tower_aws/roles/aws.create/templates/hosts.j2
@@ -1,6 +1,6 @@
 
 [local_target]
-{% if ( ( ansible_distribution == 'Fedora' ) and ( ansible_distribution_major_version >= '30' ) ) or ( ( ansible_distribution == 'RedHat' ) and ( ansible_distribution_major_version >= '8' ) ) %}
+{% if ( ansible_distribution == 'Fedora' ) and ( ansible_distribution_major_version >= '30' ) %}
 localhost  ansible_connection=local  ansible_python_interpreter='/usr/bin/python3'
 {% else %}
 localhost  ansible_connection=local  ansible_python_interpreter='/usr/bin/env python'

--- a/openshift_terraform/group_vars/all/vault.yml
+++ b/openshift_terraform/group_vars/all/vault.yml
@@ -43,5 +43,6 @@ vault_openshift_cluster_admin_password: "${INSERT_VALUE_HERE}"
 vault_number_nodes: "2"
 vault_master_size:  "m4.2xlarge"
 vault_node_size:    "m4.xlarge"
-#vault_ami:          "ami-000db10762d0c4c05"  # RHEL7.6
-vault_ami:          "ami-0916c408cb02e310b"  # RHEL7.7
+vault_ami:          "ami-b63769a1"  # RHEL7.3
+#vault_ami:          "ami-000db10762d0c4c05"  # RHEL7.6 - untested
+#vault_ami:          "ami-0916c408cb02e310b"  # RHEL7.7 - DO NOT USE, breaks deploy


### PR DESCRIPTION
**works:**
ami-b63769a1 RHEL-7.3_HVM_GA-20161026-x86_64-1-Hourly2-GP2

**fails:**
ami-0916c408cb02e310b RHEL-7.7_HVM_GA-20190723-x86_64-1-Hourly2-GP2