### PR TITLE
adding devsecops provisioning repo to make it an 'official' repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "devsecops-workshop"]
+	path = devsecops-workshop
+	url = https://github.com/epe105/devsecops-workshop.git


### PR DESCRIPTION
Need to link to this content for reference in an RFP. I added https://github.com/epe105/devsecops-workshop as a submodule. 