### PR TITLE
Update workshop ansible variable files

### DIFF
--- a/devsecops-workshop/.gitignore
+++ b/devsecops-workshop/.gitignore
@@ -1,0 +1,8 @@
+*.log
+*.bak
+tmp/
+webpage/*-index.html
+
+vars/aws.yml
+vars/aws.env
+vars/devsecops.yml

--- a/devsecops-workshop/README.md
+++ b/devsecops-workshop/README.md
@@ -1,6 +1,6 @@
 # Prerequisites
 
-We recommend that you provision about 5-10GBs of Memory per User.  For a workshop of 20 people, we recommend 4-6 m4.xlarge app nodes or larger.
+We recommend that you provision about 5-10GBs of Memory per User.  For a workshop of 20 people, we recommend 4-6 m4.2xlarge app nodes or larger.
 
  - Modern HTML5 Standard Compliant Web Browser
  - A recent stable version of Python 2.7 and the latest stable version of the boto libraries (lxml, pip, boto, boto3, and botocore)
@@ -22,8 +22,8 @@ Your workshop users in your OpenShift Environment should have the same password.
 If you'd like to setup an individual environment, use the commands below to set it up or delete the single environment.
 
 ## Ansible Playbook for setting up the Entire Workshop Enviornment on OpenShift
-- copy over you ssh key into the /keys folder and set the permission to 400
-- the Update your configuration aws.example.env and aws.example.yml in the vars/ folder
+- copy your aws.env and aws.yml files from the OCP provisioner or copy the aws.example.env and aws.example.yml
+- then Update your configuration aws.env and aws.yml in the vars/ folder
 - run the ansible playbook using the devsecops-playbook-run.sh script
 - manually restart your OpenShift Environment after the playbook run
 $ ./devsecops-playbook-run.sh script

--- a/devsecops-workshop/devsecops-playbook.yml
+++ b/devsecops-workshop/devsecops-playbook.yml
@@ -4,7 +4,7 @@
   connection: local
 
   vars_files:
-   - vars/aws.example.yml
+   - vars/aws.yml
 
   tasks:
    - import_role:
@@ -96,7 +96,7 @@
   any_errors_fatal: yes
 
   vars_files:
-   - vars/aws.example.yml
+   - vars/aws.yml
 
   roles:
    - install-oc

--- a/devsecops-workshop/devsecops-playbook.yml
+++ b/devsecops-workshop/devsecops-playbook.yml
@@ -5,6 +5,7 @@
 
   vars_files:
    - vars/aws.yml
+   - vars/devsecops.yml
 
   tasks:
    - import_role:
@@ -97,6 +98,7 @@
 
   vars_files:
    - vars/aws.yml
+   - vars/devsecops.yml
 
   roles:
    - install-oc

--- a/devsecops-workshop/vars/devsecops.example.yml
+++ b/devsecops-workshop/vars/devsecops.example.yml
@@ -1,0 +1,77 @@
+---
+# IMPORTANT: Setting this allows keyless password login and user has sudo privileges.
+# ec2_user_pass: changeme!
+
+# Generates a set of non-admin users that can be used for workshops, demos, etc.
+# Users are created with the prefix plus a number using the password specified.
+# It doesn't appear that these users are actually created in OCP. They should already exist
+# Create them as part of the cluster create or before deploying this workshop
+# Also the password here needs to match what the password for those users already is
+generic_group: docker
+generic_user: user
+generic_pass: password
+generic_count_begin: 1
+generic_count: 3
+
+# Derived public DNS entry for your cluster.
+openshift_public_hostname: "{{ cluster_name }}.{{ openshift_base_domain }}"
+cluster_name_verbose: "{{ openshift_public_hostname | replace('.', '-') }}"
+cluster_group_name: "{{ cluster_name_verbose | replace('-', '_') }}"
+
+# The directory that contains public key material.
+# This is the key used to ssh into cluster hosts
+keys_dir: 
+# The name of the ec2 instances public key.
+ec2_key_name: "{{ cluster_name_verbose }}"
+# The ec2 instances public key file.
+ec2_key_file: "{{ keys_dir }}/{{ ec2_key_name }}.pem"
+
+# The primary CIDR of the VPC.
+ec2_vpc_cidr_block: 172.31.0.0/16
+
+# Dynamically populated list of existing and new security group ids.
+bastion_security_group_ids: []
+# Targeted ec2 instance default security group name tag. Must have a public route as well.
+# Don't change this unless you're sure. If this is wrong it can mess up the security groups
+bastion_name_tag: master
+# Wetty terminal in browser port.
+bastion_port_wetty: 8888
+# Use firewalld instead of iptables on bastion host.
+bastion_firewalld: true
+
+# Default quay configuration. You can set these to something else before deploying the workshop
+clusteradmin: admin
+clusteradminpass: redhat1!
+quayiouser: admin
+quayiopassword: redhat1!
+
+# Default ansible configuration.
+ansible_user: ec2-user
+ansible_ssh_private_key_file: "{{ ec2_key_file }}"
+
+#Workshop Webpage Configuration
+ec2_name_prefix: "devsecops.{{ cluster_name }}"
+s3_state: present
+
+# Install DevSecOps cicd Projects and Quay
+# if installing workshop and using oscap, always set install_oscap to true
+# for quay to install the skopeo worker agent correctly for each cicd project,
+# run with install_cicd_project equal to true or the projects have been created previously
+install_quay: true
+install_oscap: true
+install_cicd_projects: true
+
+# Install wetty and the users for wetty
+# if install_wetty is true, the provisioner will install wetty AND create users
+# install_users only creates users
+install_wetty: true
+install_users: true
+
+#install dc metro map 
+install_dcmm: true
+
+#install tools
+install_tools: true
+
+#install devsecops webpage
+install_webpage: true


### PR DESCRIPTION
The existing workshop ansible variable file is aws.example.yml which the user is supposed to change before running the workshop. The file combines both the variables from cluster deployment and the workshop. This PR does several things:

- Separate workshop only vars into the devsecops.example.yml file
- Update the primary ansible task to use aws.yml instead of aws.example.yml
- Update the primary ansible task to use devsecops.yml
- Update the devsecops.yml file to have more comments on some of the fields to ensure new users can understand how to use them.
- Update the README to include details about these changes.