### PR TITLE
Remove RHEL and Window AMI IDs from group vars

### DIFF
--- a/ansible_tower_aws/README.md
+++ b/ansible_tower_aws/README.md
@@ -169,8 +169,6 @@ $ ansible-playbook 1_provision.yml
   rhel_count       : the number of regular RHEL instances, usually 1 per student
   win_count        : the number of Windows 2016 instances, currently not used
   region:          : defaults to "us-east-2", set to any region
-  rhel_ami_id      : defaults to "us-east-2" AMIs, uncomment us-east-1, or add your preferred region, as desired.  There are both JBoss-enabled and plain RHEL instances avalable
-  win_ami_id       : similarly to "rhel_ami_id", uncomment to match your region choice
   workshop_password: pick a password for your students to login with
   rabbit_password  : pick a password for RabbitMQ in Tower, usually not needed
   local_user       : if you are using a Mac, uncomment the Mac-specific entry, and comment the RHEL/Fedora one

--- a/ansible_tower_aws/README.md
+++ b/ansible_tower_aws/README.md
@@ -171,7 +171,7 @@ $ ansible-playbook 1_provision.yml
   region:          : defaults to "us-east-2", set to any region
   rhel_ami_id      : defaults to "us-east-2" AMIs, uncomment us-east-1, or add your preferred region, as desired.  There are both JBoss-enabled and plain RHEL instances avalable
   win_ami_id       : similarly to "rhel_ami_id", uncomment to match your region choice
-  workshop_passwoed: pick a password for your students to login with
+  workshop_password: pick a password for your students to login with
   rabbit_password  : pick a password for RabbitMQ in Tower, usually not needed
   local_user       : if you are using a Mac, uncomment the Mac-specific entry, and comment the RHEL/Fedora one
 ```


### PR DESCRIPTION
Remove RHEL and Window AMI IDs from group vars. They are not part of the variable set and are contained in another table not set by the person provisioning the workshop.