### PR TITLE
Ensure python3-pip installed for powerline (RHEL 8)

### DIFF
--- a/ansible_tower_aws/3_load.yml
+++ b/ansible_tower_aws/3_load.yml
@@ -57,6 +57,17 @@
   gather_facts: no
   roles:
     - role: LetsEncrypt
+    
+- name: Ensure python3-pip installed for powerline (RHEL 8)
+  become: yes
+  remote_user: ec2-user
+  hosts: tower_rhel_nodes
+  gather_facts: no
+  tasks:
+    - package:
+        name: python3-pip
+        state: latest
+      when: rhel_ver == 'rhel8'    
 
 - name: Configure software on nodes
   become: yes


### PR DESCRIPTION
When setting up on RHEL 8 the role to install powerline would fail b/c it needed pip3 installed.  So in 3_load.yml playbook added task for ensuring pip3 is installed on the towers for only rhel 8 systems.