### PR TITLE
Add automated run capabilities to the OCP installation playbooks

### DIFF
--- a/openshift4_aws/1_deploy_openshift.yml
+++ b/openshift4_aws/1_deploy_openshift.yml
@@ -1,7 +1,6 @@
 ---
 - hosts: localhost
 
-
   tasks:
     - name: create cluster admin and user accounts
       include_role:

--- a/openshift4_aws/2_configure_openshift.yml
+++ b/openshift4_aws/2_configure_openshift.yml
@@ -1,8 +1,8 @@
 ---
 - hosts: localhost
 
-  environment:
-    KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"
+#  environment:
+#    KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"
 
   vars:
     kubeadmin_password: "{{ lookup('file', '{{ openshift_build_path }}/auth/kubeadmin-password') }}"

--- a/openshift4_aws/2_configure_openshift.yml
+++ b/openshift4_aws/2_configure_openshift.yml
@@ -1,9 +1,6 @@
 ---
 - hosts: localhost
 
-#  environment:
-#    KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"
-
   vars:
     kubeadmin_password: "{{ lookup('file', '{{ openshift_build_path }}/auth/kubeadmin-password') }}"
 

--- a/openshift4_aws/3_teardown_openshift.yml
+++ b/openshift4_aws/3_teardown_openshift.yml
@@ -92,10 +92,6 @@
           dest: "{{ openshift_build_path }}"
           remote_src: yes
 
-      - name: Installing the OCP cluster (this will take a while. ~60 minutes)
-        shell: "{{ openshift_build_path }}/openshift-install create cluster --dir={{ openshift_build_path }} --log-level={{ openshift_installer_log_level }}"
-
-
       - name: Run the un-install
         shell: "{{ openshift_build_path }}/openshift-install destroy cluster --dir={{ openshift_build_path }} --log-level={{ openshift_installer_log_level }}"
 

--- a/openshift4_aws/3_teardown_openshift.yml
+++ b/openshift4_aws/3_teardown_openshift.yml
@@ -80,7 +80,7 @@
 
       - name: Get and set vars for the version of openshift
         set_fact:
-          openshift_version: "{{ lookup('file', 'openshift_version.txt' ) }}"
+          openshift_version: "{{ lookup('file', '{{ openshift_build_path }}/openshift_version.txt' ) }}"
 
       - name: get working directory
         shell: "pwd"

--- a/openshift4_aws/3_teardown_openshift.yml
+++ b/openshift4_aws/3_teardown_openshift.yml
@@ -77,7 +77,7 @@
         set_fact:
           openshift_version: "{{ lookup('file', 'openshift_version.txt' ) }}"
           openshift_installer_path: "{{ ansible_env.PWD }}"
-          openshift_builder_path:      "{{ openshift_installer_path }}/build"
+          openshift_build_path:      "{{ openshift_installer_path }}/build"
 
       - name: get working directory
         shell: "pwd"

--- a/openshift4_aws/3_teardown_openshift.yml
+++ b/openshift4_aws/3_teardown_openshift.yml
@@ -76,6 +76,7 @@
           mode: get
         with_items:
           - "kubeconfig"
+        ignore_errors: yes
 
       - name: Get and set vars for the version of openshift
         set_fact:

--- a/openshift4_aws/3_teardown_openshift.yml
+++ b/openshift4_aws/3_teardown_openshift.yml
@@ -1,7 +1,6 @@
 ---
 - hosts: localhost
 
-
   tasks:
   - debug:
       msg:

--- a/openshift4_aws/3_teardown_openshift.yml
+++ b/openshift4_aws/3_teardown_openshift.yml
@@ -15,6 +15,10 @@
   tasks:
   - name: Automation is removing the workshop
     block:
+      - name: Get and set vars for the version of openshift
+        set_fact:
+          openshift_build_path:      "{{ ansible_env.PWD }}/build"
+
       - name: create build directory for deployment artifacts
         file:
           path: "{{ openshift_build_path }}"
@@ -76,8 +80,6 @@
       - name: Get and set vars for the version of openshift
         set_fact:
           openshift_version: "{{ lookup('file', 'openshift_version.txt' ) }}"
-          openshift_installer_path: "{{ ansible_env.PWD }}"
-          openshift_build_path:      "{{ openshift_installer_path }}/build"
 
       - name: get working directory
         shell: "pwd"

--- a/openshift4_aws/3_teardown_openshift.yml
+++ b/openshift4_aws/3_teardown_openshift.yml
@@ -7,3 +7,104 @@
         - "execute the following command to teardown the openshift cluster"
         - "---------------------"
         - "{{ openshift_build_path }}/openshift-install destroy cluster --dir={{ openshift_build_path }} --log-level={{ openshift_installer_log_level }}"
+    when: openshift_installer_type != "automation"
+
+# Below tasks run only in "automated" install type
+- hosts: localhost
+
+  tasks:
+  - name: Automation is removing the workshop
+    block:
+      - name: create build directory for deployment artifacts
+        file:
+          path: "{{ openshift_build_path }}"
+          state: directory
+          mode: 0700
+
+      - name: get working directory
+        shell: "pwd"
+        register: pwd
+
+      - name: Create auth directory if it does not exist
+        file:
+          path: "{{ openshift_build_path }}/auth"
+          state: directory
+          mode: '0755'
+
+      - name: Check to see if workshop exists
+        aws_s3:
+          bucket: "{{ s3_bucket }}"
+          mode: list
+          prefix: "{{ s3_prefix }}/{{ workshop_type }}/{{ openshift_cluster_name }}/"
+          max_keys: 500
+        register: s3output
+
+      - name: "Print the s3output object returned"
+        debug:
+          msg: "{{ s3output }}"
+
+      - name: Cluster does not exist or has already been deleted. Exiting.
+        fail:
+          msg: Cluster does not exist.
+        when: s3output.failed
+
+      - name: "Copy in the state files from S3"
+        aws_s3:
+          bucket: "{{ s3_bucket }}"
+          object: "{{ s3_prefix }}/{{ workshop_type }}/{{ openshift_cluster_name }}/{{ item }}"
+          dest: "{{ openshift_build_path }}/{{ item }}"
+          mode: get
+        with_items:
+          - "install-config.yaml.backup"
+          - "metadata.json"
+          - "openshift_version.txt"
+          - "terraform.aws.auto.tfvars"
+          - "terraform.tfstate"
+          - "terraform.tfvars.json"
+        ignore_errors: yes
+
+      - name: "Copy in kubeconfig"
+        aws_s3:
+          bucket: "{{ s3_bucket }}"
+          #      object: "/terraform/workshops/ocp4/{{ openshift_cluster_name }}/{{ item }}"
+          object: "{{ s3_prefix }}/{{ workshop_type }}/{{ openshift_cluster_name }}/{{ item }}"
+          dest: "{{ openshift_build_path }}/auth/{{ item }}"
+          mode: get
+        with_items:
+          - "kubeconfig"
+
+      - name: Get and set vars for the version of openshift
+        set_fact:
+          openshift_version: "{{ lookup('file', 'openshift_version.txt' ) }}"
+          openshift_installer_path: "{{ ansible_env.PWD }}"
+
+      - name: get working directory
+        shell: "pwd"
+        register: pwd
+
+      - name: download and extract openshift installer
+        unarchive:
+          src: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ openshift_version }}/openshift-install-linux-{{ openshift_version }}.tar.gz
+          dest: "{{ openshift_build_path }}"
+          remote_src: yes
+
+      - name: Installing the OCP cluster (this will take a while. ~60 minutes)
+        shell: "{{ openshift_build_path }}/openshift-install create cluster --dir={{ openshift_build_path }} --log-level={{ openshift_installer_log_level }}"
+
+
+      - name: Run the un-install
+        shell: "{{ openshift_build_path }}/openshift-install destroy cluster --dir={{ openshift_build_path }} --log-level={{ openshift_installer_log_level }}"
+
+      - name: debug- mv s3 files to deleted folder
+        debug:
+          msg: "aws s3 mv --recursive s3://{{ s3_bucket }}/{{ s3_prefix }}/{{ workshop_type }}/{{ openshift_cluster_name }} s3://{{ s3_bucket }}/{{ s3_prefix }}/deleted/{{ workshop_type }}/{{ openshift_cluster_name }} "
+
+      - name: Move S3 files to be deleted
+        shell: "aws s3 mv --recursive s3://{{ s3_bucket }}/{{ s3_prefix }}/{{ workshop_type }}/{{ openshift_cluster_name }} s3://{{ s3_bucket }}/{{ s3_prefix }}/deleted/{{ workshop_type }}/{{ openshift_cluster_name }} "
+
+      - name: "Delete top level prefix"
+        aws_s3:
+          bucket: "{{ s3_bucket }}"
+          object: "{{ s3_prefix }}/{{ workshop_type }}/{{ openshift_cluster_name }}"
+          mode: delobj
+    when: openshift_installer_type == "automation"

--- a/openshift4_aws/3_teardown_openshift.yml
+++ b/openshift4_aws/3_teardown_openshift.yml
@@ -77,6 +77,7 @@
         set_fact:
           openshift_version: "{{ lookup('file', 'openshift_version.txt' ) }}"
           openshift_installer_path: "{{ ansible_env.PWD }}"
+          openshift_builder_path:      "{{ openshift_installer_path }}/build"
 
       - name: get working directory
         shell: "pwd"

--- a/openshift4_aws/README.md
+++ b/openshift4_aws/README.md
@@ -108,6 +108,17 @@ ansible-playbook 3_teardown_openshift.yml
 NOTE: The OpenShift Service Mesh workshop lab guide is located on [redhatgov.io](http://redhatgov.io/workshops/openshift_service_mesh/).
 
 ---
+## Deploys from automation tooling
+OpenShift 4 requires a priviliged AWS user account to run the installation. In order to prevent giving escalated priviliges to many users, the automation model allows for a single set of credentials to be centrally managed from your automation tooling. 
+
+With the 'automation' mode, cluster state files are copied to an S3 bucket for later retrieval when you need to delete the cluster
+The automation tooling will need access to an AWS user with required permissions as well as access to manage the designated S3 bucket (put, delete, list, etc.)
+
+To use this playbook in automation environment:
+- Set or pass the var 'openshift_installer_type' to 'automation'
+- Set or pass vars 's3_bucket', 's3_prefix', 'workshop_type' which will be assembled to form the full S3 path for storing state files (see all.yml_example notes)
+- Automation tooling would need ansible and standard required python libraries to support ansible (see the notes below and ansible installation guide)
+---
 ## Fedora 32 - Dependencies setup (DRAFT)
 Clone the ansible-ocp4-install-aws repo and change directory into the repo directory.
 

--- a/openshift4_aws/group_vars/all/all.yml_example
+++ b/openshift4_aws/group_vars/all/all.yml_example
@@ -1,6 +1,9 @@
 # Go to the following URL for a list of available OpenShift versions for installation
 # https://mirror.openshift.com/pub/openshift-v4/clients/ocp/
 
+# Valid values are 'local', and 'automation' # 'automation' is intended for automated builds/deploys
+openshift_installer_type:               automation
+
 # get installation files playbook variables
 openshift_version:                      4.4.17
 openshift_installer_path:               "{{ ansible_env.PWD }}"

--- a/openshift4_aws/group_vars/all/all.yml_example
+++ b/openshift4_aws/group_vars/all/all.yml_example
@@ -2,7 +2,7 @@
 # https://mirror.openshift.com/pub/openshift-v4/clients/ocp/
 
 # Valid values are 'local', and 'automation' # 'automation' is intended for automated builds/deploys
-openshift_installer_type:               automation
+openshift_installer_type:               local
 
 # get installation files playbook variables
 openshift_version:                      4.4.17

--- a/openshift4_aws/group_vars/all/all.yml_example
+++ b/openshift4_aws/group_vars/all/all.yml_example
@@ -39,3 +39,10 @@ jaegar_operator_version:                stable
 kiali_operator_version:                 stable
 servicemesh_operator_version:           stable
 keycloak_operator_version:              "v10.0.0"
+
+## Automation related variables
+## These get assembled to store OCP state in a bucket with a prefix like this:
+## s3://{{ s3_bucket }}/{{ s3_prefix }}/{{ workshop_type }}/{{ openshift_cluster_name }}/stateFilesHere
+#s3_bucket:                              "myStateFilesBucket"
+#s3_prefix:                              "mycustom/path/to/state/files"
+#workshop_type:                          "ocp4"

--- a/openshift4_aws/roles/create_openshift_users/tasks/main.yml
+++ b/openshift4_aws/roles/create_openshift_users/tasks/main.yml
@@ -20,6 +20,8 @@
     {{ openshift_build_path }}/oc login https://api.{{ openshift_cluster_fqdn }}:6443 --username=kubeadmin --password={{ kubeadmin_password }}
     {{ openshift_build_path }}/oc create secret generic htpass-secret --from-file=htpasswd={{ openshift_build_path }}/users.htpasswd -n openshift-config
   ignore_errors: yes
+  environment:
+    KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"
 
 - name: template htpasswd custom resource config file
   template:
@@ -31,6 +33,8 @@
     {{ openshift_build_path }}/oc login https://api.{{ openshift_cluster_fqdn }}:6443 --username=kubeadmin --password={{ kubeadmin_password }}
     {{ openshift_build_path }}/oc apply -f {{ openshift_build_path }}/htpasswd-cr.yaml
   ignore_errors: yes
+  environment:
+    KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"
 
 - name: create default project settings template
   template:
@@ -39,12 +43,16 @@
 
 - name: apply default project settings
   shell: "{{ openshift_build_path }}/oc apply -f {{ openshift_build_path }}/defaultProject.yaml"
+  environment:
+    KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"
 
 - name: add default project settings to openshift config
   shell: >
     {{ openshift_build_path }}/oc get project.config.openshift.io/cluster -o yaml
     | sed 's/spec: {}/spec: {"projectRequestTemplate":{"name": "project-request"}}/g'
     | {{ openshift_build_path }}/oc apply -f -
+  environment:
+    KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"
 
 - name: pausing 120 seconds to allow htpasswd authentication provider to start
   pause:
@@ -53,13 +61,19 @@
 - name: prime cluster_admin user and validate login
   shell: "{{ openshift_build_path }}/oc login https://api.{{ openshift_cluster_fqdn }}:6443 --username={{ openshift_cluster_admin_username }} --password={{ openshift_cluster_admin_password }}"
   ignore_errors: yes
+  environment:
+    KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"
 
 - name: add cluster role to new admin account
   shell: |
     {{ openshift_build_path }}/oc login https://api.{{ openshift_cluster_fqdn }}:6443 --username=kubeadmin --password={{ kubeadmin_password }}
     {{ openshift_build_path }}/oc adm policy add-cluster-role-to-user cluster-admin {{ openshift_cluster_admin_username }}
+  environment:
+    KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"
 
 - name: delete kubeadmin
   shell: |
     {{ openshift_build_path }}/oc login https://api.{{ openshift_cluster_fqdn }}:6443 --username={{ openshift_cluster_admin_username }} --password={{ openshift_cluster_admin_password }}
     {{ openshift_build_path }}/oc delete secrets kubeadmin -n kube-system
+  environment:
+    KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"

--- a/openshift4_aws/roles/create_openshift_users/tasks/main.yml
+++ b/openshift4_aws/roles/create_openshift_users/tasks/main.yml
@@ -58,15 +58,8 @@
   pause:
     seconds: 120
 
-- name: prime cluster_admin user and validate login
-  shell: "{{ openshift_build_path }}/oc login https://api.{{ openshift_cluster_fqdn }}:6443 --username={{ openshift_cluster_admin_username }} --password={{ openshift_cluster_admin_password }}"
-  ignore_errors: yes
-  environment:
-    KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"
-
 - name: add cluster role to new admin account
   shell: |
-    {{ openshift_build_path }}/oc login https://api.{{ openshift_cluster_fqdn }}:6443 --username=kubeadmin --password={{ kubeadmin_password }}
     {{ openshift_build_path }}/oc adm policy add-cluster-role-to-user cluster-admin {{ openshift_cluster_admin_username }}
   environment:
     KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"
@@ -75,5 +68,11 @@
   shell: |
     {{ openshift_build_path }}/oc login https://api.{{ openshift_cluster_fqdn }}:6443 --username={{ openshift_cluster_admin_username }} --password={{ openshift_cluster_admin_password }}
     {{ openshift_build_path }}/oc delete secrets kubeadmin -n kube-system
+  environment:
+    KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"
+
+- name: prime cluster_admin user and validate login
+  shell: "{{ openshift_build_path }}/oc login https://api.{{ openshift_cluster_fqdn }}:6443 --username={{ openshift_cluster_admin_username }} --password={{ openshift_cluster_admin_password }}"
+  ignore_errors: yes
   environment:
     KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -152,5 +152,4 @@
       debug:
           msg: "KUBECONFIG: \n {{ kubeconfig }}"
 
-
   when: s3_bucket is defined and openshift_installer_type == "automation"

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Set default variables for automated build (facts)
   set_fact:
     openshift_installer_path:      "{{ ansible_env.PWD }}"
-    openshift_builder_path:      "{{ openshift_installer_path }}/build"
+    openshift_build_path:      "{{ openshift_installer_path }}/build"
   when: openshift_installer_type != "automation"
 
 - name: Set binary type

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -98,7 +98,7 @@
       debug:
         msg: "{{ s3output }}"
 
-    - name: Check to see if cluster already exists with this name.
+    - name: Fail if cluster already exists with this name.
       fail:
         msg: Cluster already exists with this name
       when: s3output.s3_keys|length != 0

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -6,6 +6,12 @@
     state: directory
     mode: 0700
 
+- name: Set default variables for automated build (facts)
+    set_fact:
+      openshift_installer_path:      "{{ ansible_env.PWD }}"
+      openshift_builder_path:      "{{ openshift_installer_path }}/build"
+  when: openshift_installer_type != "automation"
+
 - name: Set binary type
   set_fact:
     openshift_binary_type: "mac"

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 
+- name: Set default variables for automated build (facts)
+  set_fact:
+    openshift_installer_path:      "{{ ansible_env.PWD }}"
+    openshift_build_path:      "{{ openshift_installer_path }}/build"
+  when: openshift_installer_type == "automation"
+
 - name: create build directory for deployment artifacts
   file:
     path: "{{ openshift_build_path }}"
     state: directory
     mode: 0700
-
-- name: Set default variables for automated build (facts)
-  set_fact:
-    openshift_installer_path:      "{{ ansible_env.PWD }}"
-    openshift_build_path:      "{{ openshift_installer_path }}/build"
-  when: openshift_installer_type != "automation"
 
 - name: Set binary type
   set_fact:

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -101,7 +101,7 @@
     - name: Check to see if cluster already exists with this name.
       fail:
         msg: Cluster already exists with this name
-      when: not s3output.failed or s3output.s3_keys|length != 0
+      when: s3output.s3_keys|length != 0
 
     - name: Installing the OCP cluster (this will take a while. ~60 minutes)
       shell: "{{ openshift_build_path }}/openshift-install create cluster --dir={{ openshift_build_path }} --log-level={{ openshift_installer_log_level }}"

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -131,8 +131,6 @@
     - name: Set facts for auth info
       set_fact:
         ocp_url: "https://console-openshift-console.apps.{{ openshift_cluster_name }}.{{ openshift_cluster_base_domain }}"
-        kubeadmin_password: "kubeadmin_password: {{ lookup('file', '{{ openshift_build_path }}/auth/kubeadmin-password') }}"
-        kubeconfig: "{{lookup('file', '{{ openshift_build_path }}/auth/kubeconfig') }}"
         openshift_cluster_fqdn: "{{ openshift_cluster_name }}.{{ openshift_cluster_base_domain }}"
 
     - name: create cluster admin and user accounts

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Set default variables for automated build (facts)
   set_fact:
     openshift_installer_path:      "{{ ansible_env.PWD }}"
-    openshift_build_path:      "{{ openshift_installer_path }}/build"
+    openshift_build_path:      "{{ ansible_env.PWD }}/build"
   when: openshift_installer_type == "automation"
 
 - name: create build directory for deployment artifacts

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -74,7 +74,7 @@
     dest: "{{ openshift_build_path }}/install-config.yaml.backup"
 
 - name: Write OCP version to openshift_version.txt
-  copy: content="{{ openshift_version }}" dest=./openshift_version.txt
+  copy: content="{{ openshift_version }}" dest="{{ openshift_build_path }}/openshift_version.txt"
   when: openshift_installer_type == "automation"
 
 - debug:
@@ -127,11 +127,30 @@
       aws_s3:
         bucket: "{{ s3_bucket }}"
         object: "{{ s3_prefix }}/{{ workshop_type }}/{{ openshift_cluster_name }}/{{ item }}"
-        src: "auth/{{ item }}"
+        src: "{{ openshift_build_path }}/auth/{{ item }}"
         mode: put
       with_items:
-        - "{{ openshift_build_path }}/kubeconfig"
-        - "{{ openshift_build_path }}/kubeadmin-password"
+        - "kubeconfig"
+        - "kubeadmin-password"
       ignore_errors: yes
+
+    - name: Set facts for auth info
+      set_fact:
+        ocp_url: "https://console-openshift-console.apps.{{ openshift_cluster_name }}.{{ openshift_cluster_base_domain }}"
+        kubeadmin_password: "kubeadmin_password: {{ lookup('file', '{{ openshift_build_path }}/auth/kubeadmin-password') }}"
+        kubeconfig: "{{lookup('file', '{{ openshift_build_path }}/auth/kubeconfig') }}"
+
+    - name: Print OCP url
+      debug:
+        msg: "{{ ocp_url }}"
+
+    - name: Print kubeadmin-password info
+      debug:
+        msg: "kubeadmin_password: {{ kubeadmin_password }}"
+
+    - name: Print KUBECONFIG
+      debug:
+          msg: "KUBECONFIG: \n {{ kubeconfig }}"
+
 
   when: s3_bucket is defined and openshift_installer_type == "automation"

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -6,29 +6,56 @@
     state: directory
     mode: 0700
 
+- name: Set binary type
+  set_fact:
+    openshift_binary_type: "mac"
+  when: ansible_os_family == "Darwin"
+
+- name: Set installer type
+  set_fact:
+    openshift_binary_type: "linux"
+  when: ansible_os_family != "Darwin"
+
 - name: download and extract openshift installer
   unarchive:
-    src: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ openshift_version }}/openshift-install-linux-{{ openshift_version }}.tar.gz
+    src: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ openshift_version }}/openshift-install-{{ openshift_binary_type }}-{{ openshift_version }}.tar.gz
     dest: "{{ openshift_build_path }}"
     remote_src: yes
 
 - name: download and extract openshift oc cli tool
   unarchive:
-    src: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ openshift_version }}/openshift-client-linux-{{ openshift_version }}.tar.gz
+    src: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ openshift_version }}/openshift-client-{{ openshift_binary_type }}-{{ openshift_version }}.tar.gz
     dest: "{{ openshift_build_path }}"
     remote_src: yes
 
+# Doing this because the naming of files is not consistent from the BU ("mac" vs "darwin")
+- name: Set binary installer type
+  set_fact:
+    openshift_binary_type: "darwin"
+  when: ansible_os_family == "Darwin"
+
 - name: extract openshift odo developer cli tool
   unarchive:
-    src: https://mirror.openshift.com/pub/openshift-v4/clients/odo/v{{ openshift_odo_version }}/odo-linux-amd64.tar.gz
+    src: https://mirror.openshift.com/pub/openshift-v4/clients/odo/v{{ openshift_odo_version }}/odo-{{ openshift_binary_type }}-amd64.tar.gz
     dest: "{{ openshift_build_path }}"
     remote_src: yes
+  when: openshift_installer_type != "automation"
+
+- name:  adding '+x' execute permissions because odo by default doesn't have execute
+  file:
+    path: "{{ openshift_build_path }}/odo"
+    mode: a+x
+  when: openshift_installer_type != "automation"
 
 - name: generate cluster ssh key pair
   openssh_keypair:
     path: "{{ openshift_build_path }}/{{ openshift_cluster_name }}-key"
     size: 4096
     type: rsa
+
+- name: Set ssh key fact
+  set_fact:
+    openshift_node_ssh_public_key: "{{ lookup('file', '{{ openshift_build_path }}/{{ openshift_cluster_name }}-key.pub') }}"
 
 - name: create openshift install-config.yaml file
   template:
@@ -40,8 +67,48 @@
     src: "{{ openshift_build_path }}/install-config.yaml"
     dest: "{{ openshift_build_path }}/install-config.yaml.backup"
 
+- name: Write OCP version to openshift_version.txt
+  copy: content="{{ openshift_version }}" dest=./openshift_version.txt
+  when: openshift_installer_type == "automation"
+
 - debug:
     msg:
       - "execute the following command to deploy the openshift cluster"
       - "--------------------"
       - "{{ openshift_build_path }}/openshift-install create cluster --dir={{ openshift_build_path }} --log-level={{ openshift_installer_log_level }}"
+  when: openshift_installer_type != "automation"
+
+- name: Block to try and copy off installation files to S3
+  block:
+    - name: Installing the OCP cluster (this will take a while. ~60 minutes)
+      shell: "{{ openshift_build_path }}/openshift-install create cluster --dir={{ openshift_installer_path }} --log-level={{ openshift_installer_log_level }}"
+
+  always:
+    - name: Copying terraform state files to S3
+      aws_s3:
+        bucket: "{{ s3_bucket }}"
+        object: "{{ s3_prefix }}/{{ workshop_type }}/{{ openshift_cluster_name }}/{{ item }}"
+        src: "{{ item }}"
+        mode: put
+      with_items:
+        - "{{ openshift_build_path }}/install-config.yaml.backup"
+        - "{{ openshift_build_path }}/metadata.json"
+        - "{{ openshift_build_path }}/openshift_version.txt"
+        - "{{ openshift_build_path }}/terraform.aws.auto.tfvars"
+        - "{{ openshift_build_path }}/terraform.tfstate"
+        - "{{ openshift_build_path }}/terraform.tfvars.json"
+        - "{{ openshift_build_path }}/{{ openshift_cluster_name}}-key.pub"
+      ignore_errors: yes
+
+    - name: Copy kubeconfig file to S3
+      aws_s3:
+        bucket: "{{ s3_bucket }}"
+        object: "{{ s3_prefix }}/{{ workshop_type }}/{{ openshift_cluster_name }}/{{ item }}"
+        src: "auth/{{ item }}"
+        mode: put
+      with_items:
+        - "{{ openshift_build_path }}/kubeconfig"
+        - "{{ openshift_build_path }}/kubeadmin-password"
+      ignore_errors: yes
+
+  when: s3_bucket is defined and openshift_installer_type == "automation"

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -148,8 +148,8 @@
       debug:
         msg: "kubeadmin_password: {{ kubeadmin_password }}"
 
-    - name: Print KUBECONFIG
-      debug:
-          msg: "KUBECONFIG: \n {{ kubeconfig }}"
+#    - name: Print KUBECONFIG
+#      debug:
+#          msg: "KUBECONFIG: \n {{ kubeconfig }}"
 
   when: s3_bucket is defined and openshift_installer_type == "automation"

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -77,13 +77,7 @@
   copy: content="{{ openshift_version }}" dest="{{ openshift_build_path }}/openshift_version.txt"
   when: openshift_installer_type == "automation"
 
-- debug:
-    msg:
-      - "execute the following command to deploy the openshift cluster"
-      - "--------------------"
-      - "{{ openshift_build_path }}/openshift-install create cluster --dir={{ openshift_build_path }} --log-level={{ openshift_installer_log_level }}"
-  when: openshift_installer_type != "automation"
-
+# Automation Componenets
 - name: Block to try and copy off installation files to S3
   block:
     - name: Check to see if workshop already exists
@@ -150,3 +144,10 @@
       debug:
         msg: "{{ ocp_url }}"
   when: s3_bucket is defined and openshift_installer_type == "automation"
+
+- debug:
+    msg:
+      - "execute the following command to deploy the openshift cluster"
+      - "--------------------"
+      - "{{ openshift_build_path }}/openshift-install create cluster --dir={{ openshift_build_path }} --log-level={{ openshift_installer_log_level }}"
+  when: openshift_installer_type != "automation"

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -140,6 +140,11 @@
         kubeadmin_password: "kubeadmin_password: {{ lookup('file', '{{ openshift_build_path }}/auth/kubeadmin-password') }}"
         kubeconfig: "{{lookup('file', '{{ openshift_build_path }}/auth/kubeconfig') }}"
 
+    - name: create cluster admin and user accounts
+      include_role:
+        name: create_openshift_users
+      when: create_openshift_users
+
     - name: Print OCP url
       debug:
         msg: "{{ ocp_url }}"
@@ -147,6 +152,7 @@
     - name: Print kubeadmin-password info
       debug:
         msg: "kubeadmin_password: {{ kubeadmin_password }}"
+
 
 #    - name: Print KUBECONFIG
 #      debug:

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -139,6 +139,7 @@
         ocp_url: "https://console-openshift-console.apps.{{ openshift_cluster_name }}.{{ openshift_cluster_base_domain }}"
         kubeadmin_password: "kubeadmin_password: {{ lookup('file', '{{ openshift_build_path }}/auth/kubeadmin-password') }}"
         kubeconfig: "{{lookup('file', '{{ openshift_build_path }}/auth/kubeconfig') }}"
+        openshift_cluster_fqdn: "{{ openshift_cluster_name }}.{{ openshift_cluster_base_domain }}"
 
     - name: create cluster admin and user accounts
       include_role:

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -149,14 +149,4 @@
     - name: Print OCP url
       debug:
         msg: "{{ ocp_url }}"
-
-    - name: Print kubeadmin-password info
-      debug:
-        msg: "kubeadmin_password: {{ kubeadmin_password }}"
-
-
-#    - name: Print KUBECONFIG
-#      debug:
-#          msg: "KUBECONFIG: \n {{ kubeconfig }}"
-
   when: s3_bucket is defined and openshift_installer_type == "automation"

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -101,7 +101,7 @@
     - name: Check to see if cluster already exists with this name.
       fail:
         msg: Cluster already exists with this name
-      when: not s3output.failed
+      when: not s3output.failed or s3output.s3_keys|length != 0
 
     - name: Installing the OCP cluster (this will take a while. ~60 minutes)
       shell: "{{ openshift_build_path }}/openshift-install create cluster --dir={{ openshift_build_path }} --log-level={{ openshift_installer_log_level }}"
@@ -111,16 +111,16 @@
       aws_s3:
         bucket: "{{ s3_bucket }}"
         object: "{{ s3_prefix }}/{{ workshop_type }}/{{ openshift_cluster_name }}/{{ item }}"
-        src: "{{ item }}"
+        src: "build/{{ item }}"
         mode: put
       with_items:
-        - "{{ openshift_build_path }}/install-config.yaml.backup"
-        - "{{ openshift_build_path }}/metadata.json"
-        - "{{ openshift_build_path }}/openshift_version.txt"
-        - "{{ openshift_build_path }}/terraform.aws.auto.tfvars"
-        - "{{ openshift_build_path }}/terraform.tfstate"
-        - "{{ openshift_build_path }}/terraform.tfvars.json"
-        - "{{ openshift_build_path }}/{{ openshift_cluster_name}}-key.pub"
+        - "install-config.yaml.backup"
+        - "metadata.json"
+        - "openshift_version.txt"
+        - "terraform.aws.auto.tfvars"
+        - "terraform.tfstate"
+        - "terraform.tfvars.json"
+        - "{{ openshift_cluster_name}}-key.pub"
       ignore_errors: yes
 
     - name: Copy kubeconfig file to S3

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -87,7 +87,7 @@
 - name: Block to try and copy off installation files to S3
   block:
     - name: Installing the OCP cluster (this will take a while. ~60 minutes)
-      shell: "{{ openshift_build_path }}/openshift-install create cluster --dir={{ openshift_installer_path }} --log-level={{ openshift_installer_log_level }}"
+      shell: "{{ openshift_build_path }}/openshift-install create cluster --dir={{ openshift_build_path }} --log-level={{ openshift_installer_log_level }}"
 
   always:
     - name: Copying terraform state files to S3

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -7,9 +7,9 @@
     mode: 0700
 
 - name: Set default variables for automated build (facts)
-    set_fact:
-      openshift_installer_path:      "{{ ansible_env.PWD }}"
-      openshift_builder_path:      "{{ openshift_installer_path }}/build"
+  set_fact:
+    openshift_installer_path:      "{{ ansible_env.PWD }}"
+    openshift_builder_path:      "{{ openshift_installer_path }}/build"
   when: openshift_installer_type != "automation"
 
 - name: Set binary type

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -86,6 +86,23 @@
 
 - name: Block to try and copy off installation files to S3
   block:
+    - name: Check to see if workshop already exists
+      aws_s3:
+        bucket: "{{ s3_bucket }}"
+        mode: list
+        prefix: "{{ s3_prefix }}/{{ workshop_type }}/{{ openshift_cluster_name }}/"
+        max_keys: 500
+      register: s3output
+
+    - name: "Print the s3output object returned"
+      debug:
+        msg: "{{ s3output }}"
+
+    - name: Check to see if cluster already exists with this name.
+      fail:
+        msg: Cluster already exists with this name
+      when: not s3output.failed
+
     - name: Installing the OCP cluster (this will take a while. ~60 minutes)
       shell: "{{ openshift_build_path }}/openshift-install create cluster --dir={{ openshift_build_path }} --log-level={{ openshift_installer_log_level }}"
 


### PR DESCRIPTION
The openshift4_aws installer needs the ability to run a cluster installation from automated tooling. This is important since OCP4 requires elevated privileges in order to run an IPI (installer provisioned infra) installation. 

The automated capabilities allow us to secure AWS user credentials using our automated tooling so that users can request builds but the keys are secured by only the automation server.

This PR gives the option to run in 'automated' workshop installation mode.