### PR TITLE
Changes for final testing from Ansible Tower

### DIFF
--- a/openshift4_aws/2_configure_openshift.yml
+++ b/openshift4_aws/2_configure_openshift.yml
@@ -9,14 +9,14 @@
     - name: create cluster admin and user accounts
       include_role:
         name: create_openshift_users
-      when: create_openshift_users == 'True'
+      when: create_openshift_users == true
 
     - name: deploy openshift service mesh
       include_role:
         name: deploy_service_mesh
-      when: deploy_service_mesh == 'True'
+      when: deploy_service_mesh == true
 
     - name: deploy and configure openshift workshop resources
       include_role:
         name: deploy_service_mesh_workshop
-      when: deploy_service_mesh_workshop == 'True'
+      when: deploy_service_mesh_workshop == true

--- a/openshift4_aws/roles/create_openshift_users/tasks/main.yml
+++ b/openshift4_aws/roles/create_openshift_users/tasks/main.yml
@@ -68,9 +68,3 @@
   shell: |
     {{ openshift_build_path }}/oc login https://api.{{ openshift_cluster_fqdn }}:6443 --username={{ openshift_cluster_admin_username }} --password={{ openshift_cluster_admin_password }}
     {{ openshift_build_path }}/oc delete secrets kubeadmin -n kube-system
-
-- name: prime cluster_admin user and validate login
-  shell: "{{ openshift_build_path }}/oc login https://api.{{ openshift_cluster_fqdn }}:6443 --username={{ openshift_cluster_admin_username }} --password={{ openshift_cluster_admin_password }}"
-  ignore_errors: yes
-  environment:
-    KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"

--- a/openshift4_aws/roles/create_openshift_users/tasks/main.yml
+++ b/openshift4_aws/roles/create_openshift_users/tasks/main.yml
@@ -68,8 +68,6 @@
   shell: |
     {{ openshift_build_path }}/oc login https://api.{{ openshift_cluster_fqdn }}:6443 --username={{ openshift_cluster_admin_username }} --password={{ openshift_cluster_admin_password }}
     {{ openshift_build_path }}/oc delete secrets kubeadmin -n kube-system
-  environment:
-    KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"
 
 - name: prime cluster_admin user and validate login
   shell: "{{ openshift_build_path }}/oc login https://api.{{ openshift_cluster_fqdn }}:6443 --username={{ openshift_cluster_admin_username }} --password={{ openshift_cluster_admin_password }}"

--- a/openshift4_aws/roles/create_openshift_users/tasks/main.yml
+++ b/openshift4_aws/roles/create_openshift_users/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Set default variables for automated build (facts)
+  set_fact:
+    kubeadmin_password: "{{ lookup('file', '{{ openshift_build_path }}/auth/kubeadmin-password') }}"
+  when: openshift_installer_type == "automation"
 
 - name: generate users.htpasswd file - create admin account entry
   htpasswd:
@@ -17,7 +21,7 @@
 
 - name: push users.htpasswd file to openshift control plane
   shell: |
-    {{ openshift_build_path }}/oc login https://api.{{ openshift_cluster_fqdn }}:6443 --username=kubeadmin --password={{ kubeadmin_password }}
+    {{ openshift_build_path }}/oc login https://api.{{ openshift_cluster_fqdn }}:6443 --username=kubeadmin --password={{ kubeadmin_password }} --insecure-skip-tls-verify
     {{ openshift_build_path }}/oc create secret generic htpass-secret --from-file=htpasswd={{ openshift_build_path }}/users.htpasswd -n openshift-config
   ignore_errors: yes
 
@@ -55,5 +59,5 @@
 
 - name: delete kubeadmin
   shell: |
-    {{ openshift_build_path }}/oc login https://api.{{ openshift_cluster_fqdn }}:6443 --username={{ openshift_cluster_admin_username }} --password={{ openshift_cluster_admin_password }}
+    {{ openshift_build_path }}/oc login https://api.{{ openshift_cluster_fqdn }}:6443 --username={{ openshift_cluster_admin_username }} --password={{ openshift_cluster_admin_password }} --insecure-skip-tls-verify
     {{ openshift_build_path }}/oc delete secrets kubeadmin -n kube-system

--- a/openshift4_aws/roles/create_openshift_users/tasks/main.yml
+++ b/openshift4_aws/roles/create_openshift_users/tasks/main.yml
@@ -20,8 +20,6 @@
     {{ openshift_build_path }}/oc login https://api.{{ openshift_cluster_fqdn }}:6443 --username=kubeadmin --password={{ kubeadmin_password }}
     {{ openshift_build_path }}/oc create secret generic htpass-secret --from-file=htpasswd={{ openshift_build_path }}/users.htpasswd -n openshift-config
   ignore_errors: yes
-  environment:
-    KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"
 
 - name: template htpasswd custom resource config file
   template:
@@ -30,11 +28,8 @@
 
 - name: apply htpasswd custom resource identity provider
   shell: |
-    {{ openshift_build_path }}/oc login https://api.{{ openshift_cluster_fqdn }}:6443 --username=kubeadmin --password={{ kubeadmin_password }}
     {{ openshift_build_path }}/oc apply -f {{ openshift_build_path }}/htpasswd-cr.yaml
   ignore_errors: yes
-  environment:
-    KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"
 
 - name: create default project settings template
   template:
@@ -43,16 +38,12 @@
 
 - name: apply default project settings
   shell: "{{ openshift_build_path }}/oc apply -f {{ openshift_build_path }}/defaultProject.yaml"
-  environment:
-    KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"
 
 - name: add default project settings to openshift config
   shell: >
     {{ openshift_build_path }}/oc get project.config.openshift.io/cluster -o yaml
     | sed 's/spec: {}/spec: {"projectRequestTemplate":{"name": "project-request"}}/g'
     | {{ openshift_build_path }}/oc apply -f -
-  environment:
-    KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"
 
 - name: pausing 120 seconds to allow htpasswd authentication provider to start
   pause:
@@ -61,8 +52,6 @@
 - name: add cluster role to new admin account
   shell: |
     {{ openshift_build_path }}/oc adm policy add-cluster-role-to-user cluster-admin {{ openshift_cluster_admin_username }}
-  environment:
-    KUBECONFIG: "{{ openshift_build_path }}/auth/kubeconfig"
 
 - name: delete kubeadmin
   shell: |

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -4,7 +4,6 @@
   set_fact:
     openshift_installer_path:      "{{ ansible_env.PWD }}"
     openshift_build_path:      "{{ ansible_env.PWD }}/build"
-    kubeadmin_password: "{{ lookup('file', '{{ openshift_build_path }}/auth/kubeadmin-password') }}"
   when: openshift_installer_type == "automation"
 
 - name: create build directory for deployment artifacts

--- a/openshift4_aws/roles/deploy_openshift/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_openshift/tasks/main.yml
@@ -4,6 +4,7 @@
   set_fact:
     openshift_installer_path:      "{{ ansible_env.PWD }}"
     openshift_build_path:      "{{ ansible_env.PWD }}/build"
+    kubeadmin_password: "{{ lookup('file', '{{ openshift_build_path }}/auth/kubeadmin-password') }}"
   when: openshift_installer_type == "automation"
 
 - name: create build directory for deployment artifacts


### PR DESCRIPTION
Changes from final testing for 'automation' deployment

Tasks in this PR:
* KUBECONFIG should not be used in a few of the steps that are removed with this. Steps should have been testing with `oc login` user
* Variable for condition in "2" playbook was using string matching (case sensitive) so changed it to bool matching
* Automation build needed the KUBECONFIG var for a couple tasks. This var was not being set outside of the "2" playbook
* Testing with latest 4.5.7 build- --insecure-skip-tls-verify flag was required for oc login
