### PR TITLE
Include mode in task to get rid of warning messages about default modes

### DIFF
--- a/ansible_tower_aws/roles/admin_server_prep/tasks/main.yml
+++ b/ansible_tower_aws/roles/admin_server_prep/tasks/main.yml
@@ -8,11 +8,13 @@
   template:
     src: aws_credentials_vault.yml.j2
     dest: "{{ deploy_working_dir }}/aws_credentials_vault.yml.pre"
+    mode: 0600
 
 - name: copy password file to working directory
   template:
     src: workshop-password.j2
     dest: "{{ deploy_working_dir }}/workshop-password"
+    mode: 0600
 
 - name: create encrypted credentials valult
   shell: "ansible-vault encrypt --vault-password-file {{ deploy_working_dir }}/workshop-password --output {{ deploy_working_dir }}/aws_credentials_vault.yml {{ deploy_working_dir }}/aws_credentials_vault.yml.pre"
@@ -28,6 +30,7 @@
   copy:
     src: "group_vars/all.yml"
     dest: "{{ deploy_working_dir }}/all.yml"
+    mode: 0644
 
 - name: remove AWS keys from staged file
   lineinfile:

--- a/ansible_tower_aws/roles/ansible.tower/tasks/nodes_setup.yml
+++ b/ansible_tower_aws/roles/ansible.tower/tasks/nodes_setup.yml
@@ -58,6 +58,7 @@
     dest: "/home/{{ system_user }}/{{ item.dest }}"
     owner: "{{ system_user }}"
     group: "{{ system_user }}"
+    mode: 0644
   with_items:
     - { src: "vimrc", dest: ".vimrc" }
 


### PR DESCRIPTION
Newer version of ansible have a differnt default mode for the template and copy tasks. This results in a warning message about the mode change in tasks that do not explicitly set the mode. I've update these few tasks with the mode option to get rid of the warning message.