### PR TITLE
Fixing syntax error from regex_replace function

### DIFF
--- a/openshift4_aws/group_vars/all/all.yml_example
+++ b/openshift4_aws/group_vars/all/all.yml_example
@@ -34,7 +34,7 @@ openshift_installer_log_level:          debug          # recommended log level o
 # service mesh operator variables
 deploy_service_mesh:                    "False"
 deploy_service_mesh_workshop:           "False"
-elasticsearch_operator_version:         "{{ openshift_version | regex_replace('^(\d+)(\.\d+).*','\1\2') }}"
+elasticsearch_operator_version:         "{{ openshift_version | regex_replace('^(\\d+)(\\.\\d+).*','\\1\\2') }}"
 jaegar_operator_version:                stable
 kiali_operator_version:                 stable
 servicemesh_operator_version:           stable


### PR DESCRIPTION
According to the regex notation used in [Ansible documentation](https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#searching-strings-with-regular-expressions), shorthand characters and backreferences used in regex filter should be preceded by two backslashes (`\\`) in YAML. According to the same documentation:

> Prior to ansible 2.0, if “regex_replace” filter was used with variables inside YAML arguments (as opposed to simpler ‘key=value’ arguments), then you needed to escape backreferences (for example, `\\1`) with 4 backslashes (`\\\\`) instead of 2 (`\\`).

So it appears that the source of your troubles with `regex_replace` is the number of backslashes. This is not surprising as it is a little different from the the notation used in *Perl* or even in the *Python* script in the rest of the project.