### PR TITLE
OCP built in web CLI idle timeout control

### DIFF
--- a/openshift4_aws/group_vars/all/all.yml_example
+++ b/openshift4_aws/group_vars/all/all.yml_example
@@ -33,7 +33,7 @@ openshift_installer_log_level:          debug          # recommended log level o
 
 # web terminal operator variables
 deploy_web_terminal:                    True
-openshift_webcli_idle_timeout:		24h
+openshift_webcli_idle_timeout:		      24h
 
 # service mesh operator variables
 deploy_service_mesh:                    false

--- a/openshift4_aws/group_vars/all/all.yml_example
+++ b/openshift4_aws/group_vars/all/all.yml_example
@@ -33,6 +33,7 @@ openshift_installer_log_level:          debug          # recommended log level o
 
 # web terminal operator variables
 deploy_web_terminal:                    True
+openshift_webcli_idle_timeout:		24h
 
 # service mesh operator variables
 deploy_service_mesh:                    false

--- a/openshift4_aws/roles/deploy_web_terminal/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_web_terminal/tasks/main.yml
@@ -6,10 +6,18 @@
     src: "{{ role_path }}/files/web-terminal-operator.yml"
     dest: "{{ openshift_build_path }}/web-terminal-operator.yml"
 
+- name: template web cli idle timeout configmap
+  template:
+    src: "cli-timeout.yaml.j2"
+    dest: "{{ openshift_build_path }}/cli-timeout.yaml"
+
 - name: login to cluster
   k8s_auth:
     state: present
   register: k8s_auth_results
+
+- name: apply modified web cli idle timeout configmap
+  shell: "{{ openshift_build_path }}/oc apply -f {{ openshift_build_path }}/cli-timeout.yaml"
 
 - name: install operators required for web terminal
   k8s:

--- a/openshift4_aws/roles/deploy_web_terminal/templates/cli-timeout.yaml.j2
+++ b/openshift4_aws/roles/deploy_web_terminal/templates/cli-timeout.yaml.j2
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  devworkspace.idle_timeout: {{ openshift_webcli_idle_timeout }}
+  devworkspace.routing.cluster_host_suffix: {{ openshift_cluster_fqdn }}
+kind: ConfigMap
+metadata:
+  name: devworkspace-controller
+  namespace: openshift-operators


### PR DESCRIPTION
OCP built in web CLI idle timeout controls to prevent the console from ending in the middle of a workshop.  Parameter added to global variables file to change timeout if needed.