### PR TITLE
Added AMIs for Sydney region and improved README

### DIFF
--- a/rhel_aws/README.md
+++ b/rhel_aws/README.md
@@ -8,6 +8,19 @@ These modules all require that you have AWS API keys available to use to provisi
 
 This repo also requires that you have Ansible installed on your local machine. For the most upto date methods of installing Ansible for your operating system [check here](http://docs.ansible.com/ansible/intro_installation.html).
 
+## Valid AWS regions
+
+By default this workshop is deployed in AWS region us-east-2 (Ohio).
+
+The available regions for the RHEL 8 workshop are:
+- us-east-2 (Ohio)
+- us-east-1 (N. Virginia)
+- ap-southeast-2 (Sydney)
+
+This is based on a dependency for the correct AWS AMIs being defined for the region in roles/aws.create/defaults/main.yml
+
+Please refer to the configuration instructions below for further information
+
 ## Detailed AWS Infrastructure Creation Guides
 
 #### OS X Catalina (10.15.x)
@@ -87,16 +100,16 @@ $ source ansible/bin/activate
 (ansible) $ ansible-playbook 2_load.yml 
 ```
 
-#### Fedora 30/31/32
+#### Fedora 30/31/32/33
 ```
 $ sudo dnf -y install git python3-boto python3-boto3 ansible awscli
 $ aws configure # fill out at least your AWS API keys, other variables are optional
 $ git clone https://github.com/RedHatGov/redhatgov.workshops.git
-$ sed -i 's/env python/env python3/' inventory/hosts
+$ sed -i 's/env python/env python3/' inventory/hosts _(probably not relevant any longer)_
 $ cd ~/src/redhatgov.workshops/rhel_aws/
 $ cp group_vars/all_example.yml group_vars/all.yml
 $ vim group_vars/all.yml # fill in all the required fields
-$ source env.sh
+$ source env.sh _(probably not relevant any longer)_
 $ ansible-playbook 1_provision.yml
 $ ansible-playbook 2_load.yml 
 ```

--- a/rhel_aws/roles/aws.create/defaults/main.yml
+++ b/rhel_aws/roles/aws.create/defaults/main.yml
@@ -31,5 +31,19 @@ regions:
       ami: "ami-0a54aef4ef3b5f881" # RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
     win2016:
       ami: "ami-08b4a0f6e106c1dba" # Windows_Server-2016-English-Full-Base-2019.02.13
+  ap-southeast-2:
+    rhel6:
+      # ami: "ami-0fcbf553f091053d7" # RHEL-6.10_HVM-20190524-x86_64-0-Hourly2-GP2 NOT AVAILABLE IN THIS REGION
+    rhel7:
+#      ami: "ami-04268981d7c33264d" # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
+      ami: "ami-864971e3" # RHEL-7.5_HVM_GA-JBEAP-7.1.2-20180629-x86_64-1-Access2-GP2 NOT AVAILABLE IN THIS REGION
+    rhel8:
+#      ami: "ami-0b2821bf4a7dba483" # RHEL-8.0_HVM-20190920-x86_64-0-Access2-GP2
+#      ami: "ami-0a54aef4ef3b5f881" # RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2 NOT AVAILABLE IN THIS REGION
+      ami: "ami-0810abbfb78d37cdf" # RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2 NOT AVAILABLE IN THIS REGION
+    win2016:
+#      ami: "ami-08b4a0f6e106c1dba" # Windows_Server-2016-English-Full-Base-2019.02.13 NOT AVAILABLE IN THIS REGION
+      ami: "ami-03808957a3743a18c" # Windows_Server-2016-English-Full-Base-2021.07.14 UNTESTED
 
+...
 ...


### PR DESCRIPTION
Hi @ajacocks starting to work on this workshop in earnest and made some very simple changes to have it run locally here in Australia.  Can you please review and comment?  

Please note that I have not added a RHEL 6 AMI in our region, meaning that this cannot be deployed on RHEL 6.  Do we need that functionality?

Thanks for your help.