### PR TITLE
Bblasco rhel8 202111b

### DIFF
--- a/ansible_tower_aws/roles/aws.create/defaults/main.yml
+++ b/ansible_tower_aws/roles/aws.create/defaults/main.yml
@@ -38,5 +38,17 @@ regions:
       ami: "ami-0a54aef4ef3b5f881" # RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
     win2016:
       ami: "ami-08b4a0f6e106c1dba" # Windows_Server-2016-English-Full-Base-2019.02.13
-
+  ap-southeast-2:
+    rhel6:
+      # ami: "ami-0fcbf553f091053d7" # RHEL-6.10_HVM-20190524-x86_64-0-Hourly2-GP2 NOT AVAILABLE IN THIS REGION
+    rhel7:
+#      ami: "ami-04268981d7c33264d" # RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2
+      ami: "ami-864971e3" # RHEL-7.5_HVM_GA-JBEAP-7.1.2-20180629-x86_64-1-Access2-GP2 NOT AVAILABLE IN THIS REGION
+    rhel8:
+#      ami: "ami-0b2821bf4a7dba483" # RHEL-8.0_HVM-20190920-x86_64-0-Access2-GP2
+#      ami: "ami-0a54aef4ef3b5f881" # RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2 NOT AVAILABLE IN THIS REGION
+      ami: "ami-0810abbfb78d37cdf" # RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2 NOT AVAILABLE IN THIS REGION
+    win2016:
+#      ami: "ami-08b4a0f6e106c1dba" # Windows_Server-2016-English-Full-Base-2019.02.13 NOT AVAILABLE IN THIS REGION
+      ami: "ami-03808957a3743a18c" # Windows_Server-2016-English-Full-Base-2021.07.14 UNTESTED
 ...

--- a/rhel_aws/README.md
+++ b/rhel_aws/README.md
@@ -184,11 +184,14 @@ Once inside the container (as root user)
 [root@3beb48b4e1cf /]# unbuffer ansible-playbook 2_load.yml -v | tee 2_load-$(date +%Y-%m-%d.%H%M).log 2>&1
 [root@3beb48b4e1cf /]# unbuffer ansible-playbook 2a_fix.yml -v | tee 2a_fix-$(date +%Y-%m-%d.%H%M).log 2>&1
 ```
-Note: In the instructions above the git repo is cloned into /root, despite mounting the /src directory from the local machine.
+*NOTE 1:* Issue observed running Fedora 34 based container in Fedora 32 host 
+: In the instructions above the git repo is cloned into /root, despite mounting the /src directory from the local machine.
 There is an issue with SELinux labels when ansible-playbook is copying files from the root user's home directory (container's ephemeral storage) into the git repo when the git repo is cloned into /src (a mapped volume).  The issue preventing files from being written into /src with an error like "mv: setting attribute 'security.selinux' for 'security.selinux': Permission denied"
 
 More details on the issue, which is actually a Python issue, can be found here:
 https://github.com/containers/podman/issues/4963
+
+*NOTE 2:* The issue above is not observed when running a Fedora 35 based container on a Fedora 35 host.
 
 Remove hosts etc. when workshop is finished
 ```

--- a/rhel_aws/README.md
+++ b/rhel_aws/README.md
@@ -185,7 +185,8 @@ Once inside the container (as root user)
 [root@3beb48b4e1cf /]# unbuffer ansible-playbook 2a_fix.yml -v | tee 2a_fix-$(date +%Y-%m-%d.%H%M).log 2>&1
 ```
 Note: In the instructions above the git repo is cloned into /root, despite mounting the /src directory from the local machine.
-This is because there is an issue with SELinux labels when ansible-playbook is copying files from the root user's home directory into the git repo when the git repo is cloned into /src.  The issue preventing files from being written /src.
+There is an issue with SELinux labels when ansible-playbook is copying files from the root user's home directory (container's ephemeral storage) into the git repo when the git repo is cloned into /src (a mapped volume).  The issue preventing files from being written into /src with an error like "mv: setting attribute 'security.selinux' for 'security.selinux': Permission denied"
+
 More details on the issue, which is actually a Python issue, can be found here:
 https://github.com/containers/podman/issues/4963
 

--- a/rhel_aws/README.md
+++ b/rhel_aws/README.md
@@ -166,9 +166,9 @@ Pre-requisites: Linux host with podman installed
 
 From Linux host (as regular non-root user)
 ```
-$ podman run -dt -v $(pwd):/src:Z quay.io/rhn_sa_bblasco/build_rhel8_workshop:test_20211110
+$ podman run -dt -v $(pwd):/src:Z quay.io/rhn_sa_bblasco/build_rhel8_workshop:latest
 $ podman ps -a
-$ podman exec -it <container name from previous command>
+$ podman exec -it <container name from previous command> /bin/bash
 ```
 
 Once inside the container (as root user)

--- a/rhel_aws/README.md
+++ b/rhel_aws/README.md
@@ -184,8 +184,8 @@ Once inside the container (as root user)
 [root@3beb48b4e1cf /]# unbuffer ansible-playbook 2_load.yml -v | tee 2_load-$(date +%Y-%m-%d.%H%M).log 2>&1
 [root@3beb48b4e1cf /]# unbuffer ansible-playbook 2a_fix.yml -v | tee 2a_fix-$(date +%Y-%m-%d.%H%M).log 2>&1
 ```
-Note: In the instructions above the git repo is cloned into /root, despite mounting the /src directory
-This is because there is an issue with selinux labels when ansible-playbook is copying files from the root user's home directory into the git repo directory, preventing files from being written.
+Note: In the instructions above the git repo is cloned into /root, despite mounting the /src directory from the local machine.
+This is because there is an issue with SELinux labels when ansible-playbook is copying files from the root user's home directory into the git repo when the git repo is cloned into /src.  The issue preventing files from being written /src.
 More details on the issue, which is actually a Python issue, can be found here:
 https://github.com/containers/podman/issues/4963
 

--- a/rhel_aws/README.md
+++ b/rhel_aws/README.md
@@ -184,6 +184,11 @@ Once inside the container (as root user)
 [root@3beb48b4e1cf /]# unbuffer ansible-playbook 2_load.yml -v | tee 2_load-$(date +%Y-%m-%d.%H%M).log 2>&1
 [root@3beb48b4e1cf /]# unbuffer ansible-playbook 2a_fix.yml -v | tee 2a_fix-$(date +%Y-%m-%d.%H%M).log 2>&1
 ```
+Note: In the instructions above the git repo is cloned into /root, despite mounting the /src directory
+This is because there is an issue with selinux labels when ansible-playbook is copying files from the root user's home directory into the git repo directory, preventing files from being written.
+More details on the issue, which is actually a Python issue, can be found here:
+https://github.com/containers/podman/issues/4963
+
 Remove hosts etc. when workshop is finished
 ```
 [root@3beb48b4e1cf /]# unbuffer ansible-playbook 3_unregister.yml -v | tee 3_unregister-$(date +%Y-%m-%d.%H%M).log 2>&1

--- a/rhel_aws/ansible.cfg
+++ b/rhel_aws/ansible.cfg
@@ -55,7 +55,7 @@ forks          = 20
 # gather_timeout = 10
 
 # additional paths to search for roles in, colon separated
-roles_path    = roles:../roles
+roles_path    = roles:../roles:~/.ansible/roles
 
 # uncomment this to disable SSH key host checking
 host_key_checking = False


### PR DESCRIPTION
All relating to RHEL 8 workshop

- Restored lost references to AMIs in ap-southeast-2
- Fixed ansible.cfg so it can use downloaded roles
- Improved/fixed explanation of podman commands when deploying from container

All tested via successful deployment and running of workshop in ap-southeast-2 yesterday for 40 students.