### PR TITLE
enable auto-selection of RHEL and Windows AMIs

### DIFF
--- a/ansible_tower_aws/3_load.yml
+++ b/ansible_tower_aws/3_load.yml
@@ -55,7 +55,7 @@
     - package:
         name: python3-pip
         state: latest
-      when: rhel_ver == 'rhel8'    
+      when: rhel_ver == 'RHEL-8'
 
 - name: Configure software on nodes
   become: yes
@@ -124,7 +124,7 @@
   gather_facts: no
   roles:
     - role: wetty
-      when: rhel_ver == 'rhel7'
+      when: rhel_ver == 'RHEL-7'
 
 - name: Configure web console (RHEL 8)
   become: yes
@@ -133,7 +133,7 @@
   gather_facts: no
   roles:
     - role: cockpit
-      when: rhel_ver == 'rhel8'
+      when: rhel_ver == 'RHEL-8'
 
 - name: Stage Maven POMs
   become: yes

--- a/ansible_tower_aws/group_vars/all_example.yml
+++ b/ansible_tower_aws/group_vars/all_example.yml
@@ -7,9 +7,13 @@
 ###############################################################################
 
 # Ensure that the name does not include special characters such as underscores, etc.
-workshop_prefix:                  "rhel" # Workshop name - NO underscores!
+workshop_prefix:                  "tower" # Workshop name - NO underscores!
+workshop_phase:                   "prod" # Can be "dev", "test", or "prod"
+workshop_appCode:                 "????" # Waiting for code creation
 execution:                        "local" # when not running from Tower, define this variable
 graphical:                        "false" # when true, install a graphical desktop on the tower nodes
+jboss:                            false # when true, configure JBoss/Maven
+
 
 ###############################################################################
 # ANSIBLE ROLE KEY         |      VALUE
@@ -19,14 +23,16 @@ deploy_working_dir:               "{{ lookup('env','PWD') }}/.redhatgov"
 # aws                      |      AWS Route 53
 domain_name:                      ""
 # aws                      |      AWS Node Counts
+tower_rhel_count:                 "2"            # RHEL node(s)
 rhel_count:                       "2"            # RHEL node(s)
 win_count:                        "0"            # Windows node(s)
 region:                           "us-east-2"    # AWS Region, configures ec2.ini too
 #------------------------------------------------------------------------------
 # AMI details
-#rhel_ver:                         "rhel7"
-rhel_ver:                         "rhel8"
-win_ver:                          "win2016"
+# these values are substrings of AMI names
+#rhel_ver:                         "RHEL-7"
+rhel_ver:                         "RHEL-8"
+win_ver:                          "Windows_Server-2016"
 ebs_root_block_size:              50
 #------------------------------------------------------------------------------
 # instance_types

--- a/ansible_tower_aws/roles/aws.create/tasks/main.yml
+++ b/ansible_tower_aws/roles/aws.create/tasks/main.yml
@@ -4,13 +4,23 @@
 #  Provisioning
 #===============================================================================
 
+- name: Find latest RHEL AMI
+  shell:
+    cmd: aws ec2 describe-images --owners 309956199498 --filters "Name=architecture,Values=x86_64" --filters "Name=name,Values={{ rhel_ver }}*x86_64*Access2*" --query 'Images[*].[Name,ImageId]' --output text  | sort -V | awk '$1 !~ /.*BETA.*/ && $1 !~ /.*GA.*/ {ami=$2} END{print ami}'
+  register: rhel_ami
+
+- name: Find latest Windows Server AMI
+  shell:
+    cmd: aws ec2 describe-images --filters "Name=architecture,Values=x86_64" --filters "Name=name,Values={{ win_ver }}-English-Full-Base*" --query 'Images[*].[Name,ImageId]' --output text  | sort -V | awk '$1 !~ /.*BETA.*/ {ami=$2} END{print ami}'
+  register: windows_ami
+
 - name: RHEL AMI
   debug:
-    msg: "Using AWS {{ region }} {{ rhel_ver }} AMI: {{ regions[region][rhel_ver].ami }}"
+    msg: "Using AWS {{ region }} {{ rhel_ver }} AMI: {{ rhel_ami.stdout }}"
 
 - name: Windows AMI
   debug:
-    msg: "Using AWS {{ region }} {{ win_ver }} AMI: {{ regions[region][win_ver].ami }}"
+    msg: "Using AWS {{ region }} {{ win_ver }} AMI: {{ windows_ami.stdout }}"
 
 - name: deploy container security workshop
   block:
@@ -224,7 +234,7 @@
     group: "{{ workshop_abbrev }}-{{ workshop_prefix }}-rhel-sg"
     region: "{{ region }}"
     instance_type: "{{ rhel_instance_type }}"
-    image: "{{ regions[region][rhel_ver].ami }}"
+    image: "{{ rhel_ami.stdout }}"
     vpc_subnet_id: "{{ ec2_subnet.subnet.id }}"
     wait: true
     instance_tags:
@@ -249,7 +259,7 @@
     group: "{{ workshop_abbrev }}-{{ workshop_prefix }}-rhel-sg"
     region: "{{ region }}"
     instance_type: "{{ rhel_instance_type }}"
-    image: "{{ regions[region][rhel_ver].ami }}"
+    image: "{{ rhel_ami.stdout }}"
     vpc_subnet_id: "{{ ec2_subnet.subnet.id }}"
     volumes: "{{ rhel_instance_vols }}"
     wait: true
@@ -275,7 +285,7 @@
     group: "{{ workshop_abbrev }}-{{ workshop_prefix }}-rhel-sg"
     region: "{{ region }}"
     instance_type: "{{ bastion_instance_type }}"
-    image: "{{ regions[region][rhel_ver].ami }}"
+    image: "{{ rhel_ami.stdout }}"
     vpc_subnet_id: "{{ ec2_subnet.subnet.id }}"
     wait: true
     instance_tags:
@@ -327,7 +337,7 @@
     group: "{{ workshop_abbrev }}-{{ workshop_prefix }}-rhel-sg"
     region: "{{ region }}"
     instance_type: "{{ tower_instance_type }}"
-    image: "{{ regions[region][rhel_ver].ami }}"
+    image: "{{ rhel_ami.stdout }}"
     vpc_subnet_id: "{{ ec2_subnet.subnet.id }}"
     wait: true
     instance_tags:
@@ -347,7 +357,7 @@
     group: "{{ workshop_abbrev }}-{{ workshop_prefix }}-win-sg"
     region: "{{ region }}"
     instance_type: "{{ win_instance_type }}"
-    image: "{{ regions[region][win_ver].ami }}"
+    image: "{{ windows_ami.stdout }}"
     vpc_subnet_id: "{{ ec2_subnet.subnet.id }}"
     user_data: "{{ lookup('file', '{{ winrm_path }}') }}"
     wait: true

--- a/ansible_tower_aws/roles/aws.remove/tasks/main.yml
+++ b/ansible_tower_aws/roles/aws.remove/tasks/main.yml
@@ -1,13 +1,23 @@
 ---
 # tasks file for roles/aws.remove
 
+- name: Find latest RHEL AMI
+  shell:
+    cmd: aws ec2 describe-images --owners 309956199498 --filters "Name=architecture,Values=x86_64" --filters "Name=name,Values={{ rhel_ver }}*x86_64*Access2*" --query 'Images[*].[Name,ImageId]' --output text  | sort -V | awk '$1 !~ /.*BETA.*/ && $1 !~ /.*GA.*/ {ami=$2} END{print ami}'
+  register: rhel_ami
+
+- name: Find latest Windows Server AMI
+  shell:
+    cmd: aws ec2 describe-images --filters "Name=architecture,Values=x86_64" --filters "Name=name,Values={{ win_ver }}-English-Full-Base*" --query 'Images[*].[Name,ImageId]' --output text  | sort -V | awk '$1 !~ /.*BETA.*/ {ami=$2} END{print ami}'
+  register: windows_ami
+
 - name: RHEL AMI
   debug:
-    msg: "Using AWS {{ region }} {{ rhel_ver }} AMI: {{ regions[region][rhel_ver].ami }}"
+    msg: "Using AWS {{ region }} {{ rhel_ver }} AMI: {{ rhel_ami.stdout }}"
 
 - name: Windows AMI
   debug:
-    msg: "Using AWS {{ region }} {{ win_ver }} AMI: {{ regions[region][win_ver].ami }}"
+    msg: "Using AWS {{ region }} {{ win_ver }} AMI: {{ windows_ami.stdout }}"
 
 - debug:
     var: tower_instance_type
@@ -207,7 +217,7 @@
     group: "{{ workshop_abbrev }}-{{ workshop_prefix }}-win-sg"
     region: "{{ region }}"
     instance_type: "{{ win_instance_type }}"
-    image: "{{ regions[region][win_ver].ami }}"
+    image: "{{ windows_ami.stdout }}"
     vpc_subnet_id: "{{ subnet_id }}"
     wait: true
     instance_ids: "{{ win_instance_ids }}"
@@ -220,7 +230,7 @@
     group: "{{ workshop_abbrev }}-{{ workshop_prefix }}-rhel-sg"
     region: "{{ region }}"
     instance_type: "{{ tower_instance_type }}"
-    image: "{{ regions[region][rhel_ver].ami }}"
+    image: "{{ rhel_ami.stdout }}"
     vpc_subnet_id: "{{ subnet_id }}"
     wait: true
     instance_ids: "{{ tower_rhel_instance_ids }}"
@@ -234,7 +244,7 @@
     group: "{{ workshop_abbrev }}-{{ workshop_prefix }}-rhel-sg"
     region: "{{ region }}"
     instance_type: "{{ rhel_instance_type }}"
-    image: "{{ regions[region][rhel_ver].ami }}"
+    image: "{{ rhel_ami.stdout }}"
     vpc_subnet_id: "{{ subnet_id }}"
     wait: true
     instance_ids: "{{ admin_rhel_instance_ids }}"
@@ -247,7 +257,7 @@
     group: "{{ workshop_abbrev }}-{{ workshop_prefix }}-rhel-sg"
     region: "{{ region }}"
     instance_type: "{{ bastion_instance_type }}"
-    image: "{{ regions[region][rhel_ver].ami }}"
+    image: "{{ rhel_ami.stdout }}"
     vpc_subnet_id: "{{ subnet_id }}"
     wait: true
     instance_ids: "{{ bastion_rhel_instance_ids }}"
@@ -260,7 +270,7 @@
     group: "{{ workshop_abbrev }}-{{ workshop_prefix }}-rhel-sg"
     region: "{{ region }}"
     instance_type: "{{ rhel_instance_type }}"
-    image: "{{ regions[region][rhel_ver].ami }}"
+    image: "{{ rhel_ami.stdout }}"
     vpc_subnet_id: "{{ subnet_id }}"
     wait: true
     instance_ids: "{{ rhel_instance_ids }}"


### PR DESCRIPTION
This patch will auto-select the AMIs in whatever region you're authenticated to.
For now, I only applied the change to ansible, but RHEL (and others?) would also need it.  And the old default AMI variables are still there too, for now.
One minor change is that the rhel_ver and win_ver variables now are a bit different in order to enable the AMI queries.

Give it a shot and let me know what you think.
