### PR TITLE
Replaced community.kubernetes with kubernetes.core in the openshift4_aws workshop

### DIFF
--- a/openshift4_aws/roles/deploy_ansible_automation/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_ansible_automation/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for deploy_ansible_automation
 - name: Determine if Ansible Tower has already been deployed
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     kind: Pod
     wait: no
     namespace: tower

--- a/openshift4_aws/roles/deploy_ansible_automation_workshop/tasks/_aws_create_base_infra.yml
+++ b/openshift4_aws/roles/deploy_ansible_automation_workshop/tasks/_aws_create_base_infra.yml
@@ -65,7 +65,7 @@
   when: ec2_key.key.private_key is defined
 
 - name: Create OpenShift ssh-key secret
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     state: present
     src: "{{ openshift_build_path }}/sshkey.yaml"
   when: ec2_key.key.private_key is defined

--- a/openshift4_aws/roles/deploy_ansible_automation_workshop/tasks/cg.yml
+++ b/openshift4_aws/roles/deploy_ansible_automation_workshop/tasks/cg.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create tower ServiceAccount for user Tower containergroup
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     kind: ServiceAccount
     state: present
     name: "containergroup-{{ item  }}"
@@ -13,7 +13,7 @@
     dest: "{{ openshift_build_path }}/tower-cg-pod-manager-{{ item }}.yml"
 
 - name: Apply pod-manager role to allow access to Tower containergroup
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', '{{ openshift_build_path }}/tower-cg-pod-manager-{{ item }}.yml') }}"
     api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
@@ -24,13 +24,13 @@
     dest: "{{ openshift_build_path }}/tower-cg-rolebinding-{{ item }}.yml"
 
 - name: Apply pod-manager rolebinding to allow access to Tower containergroup
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', '{{ openshift_build_path }}/tower-cg-rolebinding-{{ item }}.yml') }}"
     api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
 
 - name: Retrieve containergroup service account information
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api: v1
     kind: ServiceAccount
     name: "containergroup-{{ item }}"
@@ -50,7 +50,7 @@
     msg: "{{ token }}"
 
 - name: Retrieve containergroup secret
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api: v1
     kind: Secret
     name: "{{ token }}"

--- a/openshift4_aws/roles/deploy_ansible_automation_workshop/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_ansible_automation_workshop/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: Deploy the ansible edge workshop
   block:
     - name: Determine if Ansible Tower pod is online
-      community.kubernetes.k8s_info:
+      kubernetes.core.k8s_info:
         api_version: v1
         kind: Pod
         namespace: tower
@@ -40,13 +40,13 @@
         dest: "{{ openshift_build_path }}/expose-registry.yml"
 
     - name: Apply registry route expose
-      community.kubernetes.k8s:
+      kubernetes.core.k8s:
         state: present
         definition: "{{ lookup('template', '{{ openshift_build_path }}/expose-registry.yml') }}"
         api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
 
     - name: Determine if Ansible Tower pod is online
-      community.kubernetes.k8s_info:
+      kubernetes.core.k8s_info:
         api_version: v1
         kind: Pod
         namespace: tower
@@ -221,7 +221,7 @@
       with_sequence: count="{{ ansible_user_count }}"
 
     - name: Verify keycloak is present
-      community.kubernetes.k8s_info:
+      kubernetes.core.k8s_info:
         api_version: v1
         kind: Pod
         namespace: codeready-workspaces
@@ -238,7 +238,7 @@
       tags: che
 
     - name: Retrieve Keycloak secret
-      community.kubernetes.k8s_info:
+      kubernetes.core.k8s_info:
         api: v1
         kind: Secret
         name: che-identity-secret
@@ -312,7 +312,7 @@
       with_sequence: count="{{ ansible_user_count }}"
 
     - name: apply tower project - user rolebindings
-      community.kubernetes.k8s:
+      kubernetes.core.k8s:
         state: present
         definition: "{{ lookup('template', '{{ openshift_build_path }}/user{{ item }}-tower-rolebinding.yml') }}"
         api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
@@ -325,14 +325,14 @@
       with_sequence: count="{{ ansible_user_count }}"
 
     - name: apply codeready-workspaces project - user rolebindings
-      community.kubernetes.k8s:
+      kubernetes.core.k8s:
         state: present
         definition: "{{ lookup('template', '{{ openshift_build_path }}/user{{ item }}-codeready-workspaces-rolebinding.yml') }}"
         api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
       with_sequence: count="{{ ansible_user_count }}"
 
     - name: Ensure k8s namespace for user exists for edge build
-      community.kubernetes.k8s:
+      kubernetes.core.k8s:
         name: "edge-{{ item }}"
         api_version: v1
         kind: Namespace
@@ -347,7 +347,7 @@
       with_sequence: count="{{ ansible_user_count }}"
 
     - name: apply edge project - user rolebindings
-      community.kubernetes.k8s:
+      kubernetes.core.k8s:
         state: present
         definition: "{{ lookup('template', '{{ openshift_build_path }}/user{{ item }}-edge-rolebinding.yml') }}"
         api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
@@ -360,7 +360,7 @@
       with_sequence: count="{{ ansible_user_count }}"
 
     - name: apply edge project serviceaccounts
-      community.kubernetes.k8s:
+      kubernetes.core.k8s:
         state: present
         definition: "{{ lookup('template', '{{ openshift_build_path }}/user{{ item }}-edge-serviceaccount.yml') }}"
         api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"

--- a/openshift4_aws/roles/deploy_ansible_automation_workshop/tasks/usertoken.yml
+++ b/openshift4_aws/roles/deploy_ansible_automation_workshop/tasks/usertoken.yml
@@ -51,7 +51,7 @@
     register: workspace_def
 
   - name: Create user ssh-key secret
-    community.kubernetes.k8s:
+    kubernetes.core.k8s:
       state: present
       src: "{{ openshift_build_path }}/sshkey-user{{ item }}.yaml"
 

--- a/openshift4_aws/roles/deploy_codeready_workspaces/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_codeready_workspaces/tasks/main.yml
@@ -33,7 +33,7 @@
     namespace: "codeready-workspaces"
 
 - name: Verify CodeReady Workspaces Operator is present
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: Pod
     namespace: codeready-workspaces
@@ -60,7 +60,7 @@
     namespace: "codeready-workspaces"
 
 - name: Verify CodeReady Pod is present
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: Pod
     namespace: codeready-workspaces

--- a/openshift4_aws/roles/deploy_pipelines/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_pipelines/tasks/main.yml
@@ -7,7 +7,7 @@
     dest: "{{ openshift_build_path }}/openshift-pipelines-operator.yml"
 
 - name: install operators required for OpenShift Pipelines
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', '{{ openshift_build_path }}/openshift-pipelines-operator.yml') }}"
     api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"

--- a/openshift4_aws/roles/deploy_serverless/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_serverless/tasks/main.yml
@@ -7,7 +7,7 @@
     dest: "{{ openshift_build_path }}/serverless-operator.yml"
 
 - name: install operators required for serverless
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', '{{ openshift_build_path }}/serverless-operator.yml') }}"
     api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
@@ -19,7 +19,7 @@
     dest: "{{ openshift_build_path }}/knative-serving.yml"
 
 - name: Verify KnativeServing is present
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: Pod
     namespace: openshift-operators
@@ -34,14 +34,14 @@
   delay: 30
 
 - name: install knative-serving
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', '{{ openshift_build_path }}/knative-serving.yml') }}"
     api_key: "{{ k8s_auth_results.k8s_auth.api_key }}"
     namespace: "openshift-operators"
 
 - name: Wait till the autoscaler is online
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     kind: Pod
     wait: yes
     name: autoscaler

--- a/openshift4_aws/roles/deploy_signed_certs/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_signed_certs/tasks/main.yml
@@ -37,7 +37,7 @@
   when: not full_chain.stat.exists
 
 - name: Get default ingress controller
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: IngressController
     name: default
@@ -132,7 +132,7 @@
   when: not full_chain.stat.exists
 
 - name: Patch ingress to use new certificate
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     state: present
     definition:
       api_version: v1
@@ -146,7 +146,7 @@
   when: not full_chain.stat.exists
 
 - name: Patch api server to use new certificate
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     state: present
     definition:
       api_version: config.openshift.io/v1

--- a/openshift4_aws/roles/deploy_web_terminal/tasks/main.yml
+++ b/openshift4_aws/roles/deploy_web_terminal/tasks/main.yml
@@ -12,7 +12,7 @@
     dest: "{{ openshift_build_path }}/cli-timeout.yaml"
 
 - name: login to cluster
-  community.kubernetes.k8s_auth:
+  kubernetes.core.k8s_auth:
     state: present
     host: "https://api.{{ openshift_cluster_fqdn }}:6443"
     username: "{{ openshift_cluster_admin_username }}"


### PR DESCRIPTION
The community.kubernetes Ansible collection has been hard-deprecated in favor of kubernetes.core. This pull request replaces all occurrences of community.kubernetes with the recommended kubernetes.core replacement within the openshift4_aws workshop directory path.